### PR TITLE
Make dots do not expand when the argument starts with './'

### DIFF
--- a/functions/_puffer_fish_expand_dots.fish
+++ b/functions/_puffer_fish_expand_dots.fish
@@ -1,6 +1,8 @@
 function _puffer_fish_expand_dots -d 'expand ... to ../.. etc'
     set -l cmd (commandline --cut-at-cursor)
-    switch $cmd[-1]
+    set -l split (string split ' ' $cmd)
+    switch $split[-1]
+        case './*'; commandline --insert '.'
         case '*..'; commandline --insert '/..'
         case '*'; commandline --insert '.'
     end


### PR DESCRIPTION
The current behavior can be annoying when users actually want three dots (usually for programs that take it meaning recursive, e.g. `go test ./...`). I added an extra check so that the dots don't expand when the argument starts with `./`.

It currently doesn't work with `./dir\ with\ space/...`