### PR TITLE
Only bind keys in normal mode if using `fish_default_key_bindings`

### DIFF
--- a/conf.d/puffer_fish_key_bindings.fish
+++ b/conf.d/puffer_fish_key_bindings.fish
@@ -5,9 +5,9 @@ function _puffer_fish_key_bindings --on-variable fish_key_bindings
         set modes insert default
     end
 
-    bind --mode $mode[1] . _puffer_fish_expand_dots
-    bind --mode $mode[1] ! _puffer_fish_expand_bang
-    bind --mode $mode[2] --erase . !
+    bind --mode $modes[1] . _puffer_fish_expand_dots
+    bind --mode $modes[1] ! _puffer_fish_expand_bang
+    bind --mode $modes[2] --erase . !
 end
 
 _puffer_fish_key_bindings

--- a/conf.d/puffer_fish_key_bindings.fish
+++ b/conf.d/puffer_fish_key_bindings.fish
@@ -1,11 +1,13 @@
 function _puffer_fish_key_bindings --on-variable fish_key_bindings
     if test "$fish_key_bindings" = fish_default_key_bindings
-        bind . _puffer_fish_expand_dots
-        bind ! _puffer_fish_expand_bang
+        set modes default insert
     else
-        bind . -M insert _puffer_fish_expand_dots
-        bind ! -M insert _puffer_fish_expand_bang
+        set modes insert default
     end
+
+    bind --mode $mode[1] . _puffer_fish_expand_dots
+    bind --mode $mode[1] ! _puffer_fish_expand_bang
+    bind --mode $mode[2] --erase . !
 end
 
 _puffer_fish_key_bindings

--- a/conf.d/puffer_fish_key_bindings.fish
+++ b/conf.d/puffer_fish_key_bindings.fish
@@ -1,7 +1,14 @@
-bind . _puffer_fish_expand_dots
-bind . -M insert _puffer_fish_expand_dots
-bind ! _puffer_fish_expand_bang
-bind ! -M insert _puffer_fish_expand_bang
+function _puffer_fish_key_bindings --on-variable fish_key_bindings
+    if test "$fish_key_bindings" = fish_default_key_bindings
+        bind . _puffer_fish_expand_dots
+        bind ! _puffer_fish_expand_bang
+    else
+        bind . -M insert _puffer_fish_expand_dots
+        bind ! -M insert _puffer_fish_expand_bang
+    end
+end
+
+_puffer_fish_key_bindings
 
 set -l uninstall_event (basename (status -f) .fish)_uninstall
 


### PR DESCRIPTION
Though not really problematic, I believe the keybindings should only work in insert mode :)

Also added handler for mode switching like [autopair.fish](https://github.com/jorgebucaran/autopair.fish/blob/1222311994a0730e53d8e922a759eeda815fcb62/conf.d/autopair.fish#L7-L31).