### PR TITLE
Remove unnecessary `basename` call

### DIFF
--- a/conf.d/puffer_fish_key_bindings.fish
+++ b/conf.d/puffer_fish_key_bindings.fish
@@ -1,3 +1,5 @@
+status is-interactive || exit
+
 function _puffer_fish_key_bindings --on-variable fish_key_bindings
     if test "$fish_key_bindings" = fish_default_key_bindings
         set modes default insert

--- a/conf.d/puffer_fish_key_bindings.fish
+++ b/conf.d/puffer_fish_key_bindings.fish
@@ -12,9 +12,9 @@ end
 
 _puffer_fish_key_bindings
 
-set -l uninstall_event (basename (status -f) .fish)_uninstall
+set -l uninstall_event puffer_fish_key_bindings_uninstall
 
-function $uninstall_event --on-event $uninstall_event
+function _$uninstall_event --on-event $uninstall_event
     bind -e .
     bind -e !
 end


### PR DESCRIPTION
I think it doesn't make sense to call `basename` if it is a fixed string. Also see the profile below:

```
141     2177    ----> source $file
9       9       -----> function _puffer_fish_key_bindings --on-variable fish_key_bindings...
23      85      -----> _puffer_fish_key_bindings
8       28      ------> if test "$fish_key_bindings" = fish_default_key_bindings...
12      12      -------> test "$fish_key_bindings" = fish_default_key_bindings
8       8       -------> set modes default insert
12      12      ------> bind --mode $modes[1] . _puffer_fish_expand_dots
10      10      ------> bind --mode $modes[1] ! _puffer_fish_expand_bang
12      12      ------> bind --mode $modes[2] --erase . !
98      1928    -----> set -l uninstall_event (basename (status -f) .fish)_uninstall
1812    1830    ------> basename (status -f) .fish
18      18      -------> status -f
14      14      -----> function $uninstall_event --on-event $uninstall_event...
```

Sourcing the entire file takes 2177 microseconds, and that basename along takes 1830, that's not worth it.

This PR also:

- Prefixes the uninstall function with a underscore, as a convention for private functions.
- Skip the config file if we are not in interactive mode