### PR TITLE
feat: don't expand ... in `target/...`

### DIFF
--- a/functions/_puffer_fish_expand_dots.fish
+++ b/functions/_puffer_fish_expand_dots.fish
@@ -3,7 +3,14 @@ function _puffer_fish_expand_dots -d 'expand ... to ../.. etc'
     set -l split (string split ' ' $cmd)
     switch $split[-1]
         case './*'; commandline --insert '.'
-        case '*..'; commandline --insert '/..'
+        case '*..'
+            # Only expand if the string consists of dots and slashes.
+            # We don't want to expand strings like `bazel build target/...`.
+            if string match --quiet --regex '^[/.]*$' $split[-1]
+                commandline --insert '/..'
+            else
+                commandline --insert '.'
+            end
         case '*'; commandline --insert '.'
     end
 end


### PR DESCRIPTION
Tools like Bazel legitimately use `...` as a meaningful set of characters. This plugin has been interfering with it by expanding it to `../..`.