### PR TITLE
fix: do not error when more than one current token

### DIFF
--- a/functions/_puffer_fish_expand_bang.fish
+++ b/functions/_puffer_fish_expand_bang.fish
@@ -1,4 +1,9 @@
 function _puffer_fish_expand_bang
+    set -l current_token (commandline -t)
+    if not test (count $current_token) -eq 1
+        commandline -i '!'
+        return
+    end
     switch (commandline -t)
       case '!'
         commandline -t $history[1]

--- a/functions/_puffer_fish_expand_lastarg.fish
+++ b/functions/_puffer_fish_expand_lastarg.fish
@@ -1,4 +1,9 @@
 function _puffer_fish_expand_lastarg
+    set -l current_token (commandline -t)
+    if not test (count $current_token) -eq 1
+        commandline -i '$'
+        return
+    end
     switch (commandline -t)
       case '!'
         commandline -t ""


### PR DESCRIPTION
Typing `$` or `!` was causing an error instead of inserting the symbol when typing in the following command:

```fish
gh api graphql -F owner='{owner}' -F name='{repo}' -f query='
  query($name: String!
```

It errored when I was typing out `$` and after fixing that, it errored on `!`. This "fixes" the issue by doing the fallback of inserting the typed symbol, but maybe we still want to consider the expansion.
